### PR TITLE
add lxqt-palette.conf for known dark themes

### DIFF
--- a/themes/Leech/lxqt-palette.conf
+++ b/themes/Leech/lxqt-palette.conf
@@ -1,0 +1,9 @@
+[Palette]
+base_color=#1c2428
+highlight_color=#004633
+highlighted_text_color=#c4c7ff
+link_color=#5555ff
+link_visited_color=#b075b0
+text_color=#c7c7d8
+window_color=#222d32
+window_text_color=#c7c7d8

--- a/themes/ambiance/lxqt-palette.conf
+++ b/themes/ambiance/lxqt-palette.conf
@@ -1,0 +1,9 @@
+[Palette]
+base_color=#1c2428
+highlight_color=#004633
+highlighted_text_color=#c4c7ff
+link_color=#5555ff
+link_visited_color=#b075b0
+text_color=#c7c7d8
+window_color=#222d32
+window_text_color=#c7c7d8

--- a/themes/dark/lxqt-palette.conf
+++ b/themes/dark/lxqt-palette.conf
@@ -1,0 +1,9 @@
+[Palette]
+base_color=#1c2428
+highlight_color=#004633
+highlighted_text_color=#c4c7ff
+link_color=#5555ff
+link_visited_color=#b075b0
+text_color=#c7c7d8
+window_color=#222d32
+window_text_color=#c7c7d8

--- a/themes/frost/lxqt-palette.conf
+++ b/themes/frost/lxqt-palette.conf
@@ -1,0 +1,9 @@
+[Palette]
+base_color=#1c2428
+highlight_color=#004633
+highlighted_text_color=#c4c7ff
+link_color=#5555ff
+link_visited_color=#b075b0
+text_color=#c7c7d8
+window_color=#222d32
+window_text_color=#c7c7d8


### PR DESCRIPTION
Colors are based on the "Ambience" theme which served as reference.

Note: The palettes don't have any effect until implementation in `liblxqt` is done.