### PR TITLE
A workaround when kiconthemes is installed

### DIFF
--- a/themes/kvantum/lxqt-panel.qss
+++ b/themes/kvantum/lxqt-panel.qss
@@ -342,8 +342,11 @@ TrayIcon {
  * Main menu
  */
 #MainMenu {
+    color: white;
+    margin: 1px;
+    padding: 1px;
+    border: 1px solid transparent;
     qproperty-icon: url(/lxqt-panel/mainmenu.svg);
-    color: #EEEEEE;
 }
 
 #MainMenu ActionView {


### PR DESCRIPTION
If kiconthemes ≥ 5.80.0 is installed, stylesheet SVG icons will be controlled by it but it has a bug that makes the main menu icon disappear in one LXQt theme. Therefore, a workaround is added to that theme.

NOTE: The bug(s) of kiconthemes ≥ 5.80.0 may also make some icons ugly. Unfortunately, we can do nothing about it.