### PR TITLE
Circumvent problems of Qt stylesheet in kvantum theme

### DIFF
--- a/themes/kvantum/lxqt-panel.qss
+++ b/themes/kvantum/lxqt-panel.qss
@@ -270,6 +270,8 @@ QMenu::separator {
 }
 
 QMenu::item {
+    border: 7px solid transparent;
+    padding: 0px 20px 0px 20px;
     background: transparent;
     color: white;
 }


### PR DESCRIPTION
This simple change is a workaround for 3 bugs of Qt stylesheet, revealed by kvantum theme: (1) selected menu arrows weren't shown; (2) taskbar right-click (sub)menus didn't have enough width; and (3) selected menu check-boxes could have a weird border, sometimes when checked, sometimes when unchecked.

Those problems don't show up in most themes because they include the workarounds automatically.