### PR TITLE
KDE-Plasma WorldClock margin fix

### DIFF
--- a/themes/KDE-Plasma/lxqt-panel.qss
+++ b/themes/KDE-Plasma/lxqt-panel.qss
@@ -459,7 +459,7 @@ TrayIcon {
  * WorldClock
  */
 #WorldClock {
-    margin: 3px;
+    margin: 3px 0 0 0;
     padding-top: 2px;
     border-top: 3px solid transparent;
     color: rgba(54, 54, 54, 100%);


### PR DESCRIPTION
Makes the over-bar go over all the text.

![before](https://user-images.githubusercontent.com/96850319/201805914-797a0378-5a48-4603-9f91-b965ea9d48a7.png)
![after](https://user-images.githubusercontent.com/96850319/201805929-4843435d-8328-47d6-a458-117c3f94d277.png)
