### PR TITLE
Transparent background in buttons and clock

### DIFF
--- a/themes/Arch-Colors/lxqt-panel.qss
+++ b/themes/Arch-Colors/lxqt-panel.qss
@@ -135,7 +135,7 @@ QMenu::indicator:non-exclusive:checked {
  */
 #MainMenu {
     qproperty-icon: url(mainmenu.svg);
-    background: #162635;
+    background: transparent;
     margin: 0px;
     padding: 3px;
     color: #e7eff1;
@@ -188,9 +188,8 @@ QMenu::indicator:non-exclusive:checked {
  */
 #FancyMenu {
     qproperty-icon: url(mainmenu.svg);
-    background: #162635;
+    background: transparent;
     margin: 0px;
-    padding: 3px;
     color: #e7eff1;
 }
 
@@ -364,12 +363,10 @@ StatusNotifierButton {
 #VolumePlugin QToolButton {
     margin: 2px;
     padding: 2px;
-    background: #162635;
 }
 
 #VolumePlugin QToolButton:hover {
     background: #1899da;
-    border-radius: 2px;
 }
 
 VolumePopup {
@@ -418,7 +415,7 @@ VolumePopup > QSlider::sub-page:vertical {
 #WorldClock {
     margin: 0px;
     padding: 0px;
-    background-color: #162635;
+    background: transparent;
 }
 
 #WorldClock QLabel {
@@ -426,7 +423,7 @@ VolumePopup > QSlider::sub-page:vertical {
     margin: 0px;
     color: #e7eff1;
     qproperty-alignment: alignCenter;
-    background-color: #162635;
+    background: transparent;
 }
 
 /*
@@ -635,6 +632,10 @@ QCalendarWidget QSpinBox {
 /*
  * Backlight Plugin
  */
+
+#BacklightPlugin QToolButton:hover {
+    background: #1899da;
+}
 #Backlight > SliderDialog > QToolButton {
     margin: 2px;
     padding: 2px;

--- a/themes/Clearlooks/lxqt-panel.qss
+++ b/themes/Clearlooks/lxqt-panel.qss
@@ -20,11 +20,12 @@ Plugin > QWidget > QToolButton,
 Plugin > QWidget > QToolButton > QWidget > QToolButton,
 
 LXQtPanelPlugin > QToolButton {
-    background: #edeceb;
+    background: transparent;
     margin: 0px;
     padding: 2px;
     color: #1a1a1a;
 }
+
 
 QToolTip {
     border: 1px solid palette(text);

--- a/themes/Valendas/lxqt-panel.qss
+++ b/themes/Valendas/lxqt-panel.qss
@@ -185,13 +185,13 @@ QMenu QToolButton {
 
 #FancyMenu {
     qproperty-icon: url(mainmenu.svg);
-    background-color: rgba(0, 0, 0,);
+    background: transparent;
     margin-right: 5px;
     color: #ebebeb;
 }
 
 #FancyMenu:hover {
-    background-color: rgba(5, 0, 0, 45%);
+    color: white;
 }
 
 #FancyMenu:pressed {
@@ -247,8 +247,6 @@ LXQtFancyMenuWindow {
     background: #444444;
     border: 1px solid grey;
 }
-
-#FancyMenu QToolButton:focus
 
 #FancyMenu QToolButton:pressed {
     background: #b6b6b6;
@@ -705,14 +703,14 @@ QCalendarWidget QSpinBox {
  */
 #WorldClock {
     color: #eef5fc;
-    background: #2f2f2f;
+    background: transparent;
 }
 
 #WorldClock QLabel {
     margin: 2px;
     padding: 4px;
     color: #eef5fc;
-    background: #2f2f2f;
+    background: transparent;
 }
 
 /*


### PR DESCRIPTION
Fixes the rest of https://github.com/lxqt/lxqt-themes/issues/100

Removed also the redundant line in Valendas and another fix in this theme.
Didn't touch taskbar and desktop switch buttons, in some themes transparent panel is a little bit ugly.
Testing I noticed that desktop switcher with Leech doesn't highlight active one.