### PR TITLE
Make Color Picker divider visible in Clearlooks, Leech

### DIFF
--- a/themes/Clearlooks/lxqt-panel.qss
+++ b/themes/Clearlooks/lxqt-panel.qss
@@ -9,8 +9,8 @@ LXQtPanel #BackgroundWidget {
     border: 0px solid #1a1a1a;
 }
 
-Plugin > QWidget,
-Plugin > QWidget > QWidget {
+Plugin > QWidget/*,
+Plugin > QWidget > QWidget*/ {
     border: 0px;
     color: rgba(0, 0, 0, 100%); /* Color of text on same */
 }
@@ -18,7 +18,6 @@ Plugin > QWidget > QWidget {
 Plugin > QToolButton,
 Plugin > QWidget > QToolButton,
 Plugin > QWidget > QToolButton > QWidget > QToolButton,
-
 LXQtPanelPlugin > QToolButton {
     background: transparent;
     margin: 0px;
@@ -573,4 +572,20 @@ LXQtFancyMenuWindow {
     color: #ffffff;
     border: 1px solid #000000;
     border-radius: 3px;
+}
+
+/*
+ * StatusNotifier
+ */
+
+#StatusNotifier QToolButton {
+    border: 0px;
+}
+
+/*
+ * ColorPicker
+ */
+
+#ColorPicker QToolButton {
+    border: 0px;
 }

--- a/themes/Clearlooks/lxqt-panel.qss
+++ b/themes/Clearlooks/lxqt-panel.qss
@@ -9,8 +9,7 @@ LXQtPanel #BackgroundWidget {
     border: 0px solid #1a1a1a;
 }
 
-Plugin > QWidget/*,
-Plugin > QWidget > QWidget*/ {
+Plugin > QWidget {
     border: 0px;
     color: rgba(0, 0, 0, 100%); /* Color of text on same */
 }

--- a/themes/Leech/lxqt-panel.qss
+++ b/themes/Leech/lxqt-panel.qss
@@ -9,8 +9,8 @@ LXQtPanel #BackgroundWidget {
     border: 0px solid #555555;
 }
 
-Plugin > QWidget,
-Plugin > QWidget > QWidget {
+Plugin > QWidget/*,
+Plugin > QWidget > QWidget*/ {
     border: 0px;
     color: #ffffff; /* Color of text on same */
 }

--- a/themes/Leech/lxqt-panel.qss
+++ b/themes/Leech/lxqt-panel.qss
@@ -9,8 +9,7 @@ LXQtPanel #BackgroundWidget {
     border: 0px solid #555555;
 }
 
-Plugin > QWidget/*,
-Plugin > QWidget > QWidget*/ {
+Plugin > QWidget {
     border: 0px;
     color: #ffffff; /* Color of text on same */
 }


### PR DESCRIPTION
Set "border: 0px;" only for required widgets.

Closes #102