### PR TITLE
Clearlooks: Fix styling regression from #132

### DIFF
--- a/themes/Clearlooks/lxqt-panel.qss
+++ b/themes/Clearlooks/lxqt-panel.qss
@@ -169,6 +169,7 @@ QMenu::indicator:non-exclusive:checked:selected {
 }
 
 #QuickLaunch QToolButton {
+    border: 0px;
     background-color: transparent;
     margin: 1px;
     padding: 2px;


### PR DESCRIPTION
In #132 `Plugin > QWidget > QWidget {` was removed and its properties copied into specific blocks.

Missing `border: 0px;` in `#QuickLaunch QToolButton` made it styled weird on hover.