### PR TITLE
Fix Fancymenu background text for appview

### DIFF
--- a/themes/Arch-Colors/lxqt-panel.qss
+++ b/themes/Arch-Colors/lxqt-panel.qss
@@ -207,6 +207,10 @@ LXQtFancyMenuWindow{
     border: 1px solid grey;
 }
 
+#FancyMenu QLabel {
+    color: #d7e3e6;
+}
+
 #FancyMenu QListView::item {
     color: #d7e3e6;
     padding: 5px 3px 5px 3px;

--- a/themes/Leech/lxqt-panel.qss
+++ b/themes/Leech/lxqt-panel.qss
@@ -294,6 +294,10 @@ QMenu::left-arrow:selected {
     color: #ffffff;
 }
 
+#FancyMenu QLabel {
+    color: #ffffff;
+}
+
 #FancyMenu QLineEdit {
     color: #ffffff;
     background: #000000;

--- a/themes/Valendas/lxqt-panel.qss
+++ b/themes/Valendas/lxqt-panel.qss
@@ -200,6 +200,10 @@ LXQtFancyMenuWindow {
    background-color: #3b3b3b; /* disabled transparency because buggy */
 }
 
+#FancyMenu QLabel {
+    color: white;
+}
+
 #FancyMenu QLineEdit {
     margin: 0;
     padding: 6px;

--- a/themes/ambiance/lxqt-panel.qss
+++ b/themes/ambiance/lxqt-panel.qss
@@ -337,6 +337,10 @@ LXQtFancyMenuWindow{
     border: 1px solid #5e5e5e;
 }
 
+#FancyMenu QLabel {
+    color: #f2f1f0;
+}
+
 #FancyMenu #CategoryView {
     background-color: #32312e;
 }

--- a/themes/dark/lxqt-panel.qss
+++ b/themes/dark/lxqt-panel.qss
@@ -473,6 +473,10 @@ LXQtFancyMenuWindow {
     background: rgba(0, 0, 0, 0%);/*disabled transparency because buggy*/
 }
 
+#FancyMenu QLabel {
+    color: white;
+}
+
 #FancyMenu QLineEdit {
     background: black;
     border: 1px solid #3c3c3c;

--- a/themes/frost/lxqt-panel.qss
+++ b/themes/frost/lxqt-panel.qss
@@ -251,6 +251,10 @@ ActionView::item:hover {
     padding: 4px;
 }
 
+#FancyMenu QLabel {
+    color: palette(window);
+}
+
 #FancyMenu QLineEdit {
     background: palette(text);
     border: none;

--- a/themes/kvantum/lxqt-panel.qss
+++ b/themes/kvantum/lxqt-panel.qss
@@ -420,6 +420,10 @@ LXQtFancyMenuWindow{
     background: #2E2E2E;
 }
 
+#FancyMenu QLabel  {
+    color: white;
+}
+
 #FancyMenu QLineEdit {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #141414, stop:0.2 #232323, stop:0.98 #242424 stop:1 #323232);
     border: 1px solid #000000;


### PR DESCRIPTION
This PR fixes an issue where, if used with the default palette, some themes' text for Favorites becomes illegible. Here are some example before and after screens, to show what this fixes: 

Kvantum before:
![kvantum-before](https://github.com/user-attachments/assets/aad002d6-141b-4c1e-b640-b10c7282b1a9)

after: 
![kvantum](https://github.com/user-attachments/assets/5f0a9873-87f0-4b68-9e7d-ef77593df1fd)

Arch-colors before:
![arch-before](https://github.com/user-attachments/assets/fc9b8acf-c8d5-4d53-945f-2b5fe7f34c8d)

Arch-colors after: 
![arch-after](https://github.com/user-attachments/assets/c187e79e-a2c8-49a3-866f-2bfa83ef5593)

Frost before:
![frost-before](https://github.com/user-attachments/assets/f0ee4e00-7b32-465d-96c7-9d333378ff29)

Frost after: 
![frost-after](https://github.com/user-attachments/assets/4b1c7ddd-ec7d-4e3e-8f72-36cc0405b35b)


When making these fixes, I used the same colors as the category area next to it, to ensure consistency. 

Every other part of the theme remains legible regardless of palette, so why not this area, too? 