### PR TITLE
Clearlooks, Leech: add basic styling to mount plugin

### DIFF
--- a/themes/Clearlooks/lxqt-panel.qss
+++ b/themes/Clearlooks/lxqt-panel.qss
@@ -589,3 +589,15 @@ LXQtFancyMenuWindow {
 #ColorPicker QToolButton {
     border: 0px;
 }
+
+/*
+ * Mount plugin
+ */
+
+#LXQtMountPopup #DiskButton {
+    margin-right: 2px;
+}
+
+#LXQtMountPopup #NoDiskLabel {
+    padding: 2px;
+}

--- a/themes/Clearlooks/lxqt-panel.qss
+++ b/themes/Clearlooks/lxqt-panel.qss
@@ -594,8 +594,10 @@ LXQtFancyMenuWindow {
  * Mount plugin
  */
 
-#LXQtMountPopup #DiskButton {
-    margin-right: 2px;
+#LXQtMountPopup #DiskButton,
+#LXQtMountPopup #EjectButton
+{
+    margin: 1px;
 }
 
 #LXQtMountPopup #NoDiskLabel {

--- a/themes/Leech/lxqt-panel.qss
+++ b/themes/Leech/lxqt-panel.qss
@@ -556,3 +556,15 @@ DesktopSwitch
     border: 1px solid #969696;
     border-radius: 2px;
 }
+
+/*
+ * Mount plugin
+ */
+
+#LXQtMountPopup #DiskButton {
+    margin-right: 2px;
+}
+
+#LXQtMountPopup #NoDiskLabel {
+    padding: 2px;
+}

--- a/themes/Leech/lxqt-panel.qss
+++ b/themes/Leech/lxqt-panel.qss
@@ -561,8 +561,10 @@ DesktopSwitch
  * Mount plugin
  */
 
-#LXQtMountPopup #DiskButton {
-    margin-right: 2px;
+#LXQtMountPopup #DiskButton,
+#LXQtMountPopup #EjectButton
+{
+    margin: 1px;
 }
 
 #LXQtMountPopup #NoDiskLabel {


### PR DESCRIPTION
The two themes with no plugin-mount styling were Clearlooks and Leech. I noticed in Clearlooks that the mount plugin looked unthemed.

This adds slight padding/margins.