### PR TITLE
Light: loosen margins for taskbar buttons

### DIFF
--- a/themes/light/lxqt-panel.qss
+++ b/themes/light/lxqt-panel.qss
@@ -162,7 +162,7 @@ LXQtPanel[position="1"] #DesktopSwitch QToolButton
 LXQtTaskButton {
     border: 2px groove silver;
     border-radius: 6px;
-    margin: 3px 0 3px 0;
+    margin: 2px 0 2px 0;
 }
 
 #TaskBar QToolButton:on {
@@ -171,7 +171,7 @@ LXQtTaskButton {
 
 #TaskBar QToolButton:on,
 #TaskBar QToolButton:hover {
-    margin: 4px 1px 4px 1px;
+    margin: 2px 1px 2px 1px;
     border-radius: 4px;
     border: 1px solid #80a8d3;
 }


### PR DESCRIPTION
They always seemed too tight on the contents

Before:
![before](https://github.com/user-attachments/assets/473a49ea-1223-48e9-8afe-228f9a7333fe)

After:
![after](https://github.com/user-attachments/assets/f53bc176-2837-4c71-9c49-a788f39e5a92)
