### PR TITLE
Reduce margins/padding for taskbar groups

### DIFF
--- a/themes/Arch-Colors/lxqt-panel.qss
+++ b/themes/Arch-Colors/lxqt-panel.qss
@@ -337,6 +337,7 @@ LXQtFancyMenuWindow{
 }
 
 #TaskBar LXQtGroupPopup > QToolButton {
+    margin: 0;
     color: #e7eff1;
 }
 

--- a/themes/Clearlooks/lxqt-panel.qss
+++ b/themes/Clearlooks/lxqt-panel.qss
@@ -121,6 +121,7 @@ QMenu::indicator:non-exclusive:checked:selected {
 }
 
 /* Taskbar */
+
 #TaskBar QToolButton {
     margin-left: 1px;
     margin-right: 1px;
@@ -159,6 +160,10 @@ QMenu::indicator:non-exclusive:checked:selected {
     color: #ffffff;
     border: 1px solid #000000;
     border-radius: 3px;
+}
+
+#TaskBar LXQtGroupPopup QToolButton {
+    margin: 0;
 }
 
 /* Quick Launch (Icon bar) */

--- a/themes/KDE-Plasma/lxqt-panel.qss
+++ b/themes/KDE-Plasma/lxqt-panel.qss
@@ -324,6 +324,10 @@ LXQtFancyMenuWindow {
     border: 1px solid rgba(30, 145, 255, 100%);
 }
 
+#TaskBar LXQtGroupPopup QToolButton {
+    margin: 0;
+}
+
 /*
  * QuickLaunch
  */

--- a/themes/Leech/lxqt-panel.qss
+++ b/themes/Leech/lxqt-panel.qss
@@ -73,6 +73,11 @@ LXQtPanelPlugin > QToolButton {
     border-radius: 2px;
 }
 
+#TaskBar LXQtGroupPopup QToolButton {
+    margin: 0;
+    padding: 0;
+}
+
 /* Quick Launch (Icon bar) */
 #QuickLaunchPlaceHolder {
     background-color: transparent;

--- a/themes/Valendas/lxqt-panel.qss
+++ b/themes/Valendas/lxqt-panel.qss
@@ -375,6 +375,10 @@ LXQtFancyMenuWindow {
     border: 1px solid black;
 }
 
+#TaskBar LXQtGroupPopup QToolButton {
+    margin: 0;
+}
+
 /*
  * Tray Plugin
  */

--- a/themes/ambiance/lxqt-panel.qss
+++ b/themes/ambiance/lxqt-panel.qss
@@ -228,6 +228,10 @@ QCalendarWidget QWidget {
     border: 1px solid #f88657;
 }
 
+#TaskBar LXQtGroupPopup QToolButton {
+    margin: 0;
+}
+
 /*
  * Main menu
  */

--- a/themes/dark/lxqt-panel.qss
+++ b/themes/dark/lxqt-panel.qss
@@ -237,6 +237,10 @@ VolumePopup > QSlider::sub-page:vertical {
     ;
 }
 
+#TaskBar LXQtGroupPopup QToolButton {
+    margin: 0;
+}
+
 /*
  * Calendar Widget
  */

--- a/themes/frost/lxqt-panel.qss
+++ b/themes/frost/lxqt-panel.qss
@@ -409,6 +409,10 @@ QListView::item:hover {
     border: 1px solid palette(highlight);
 }
 
+#TaskBar LXQtGroupPopup QToolButton {
+    margin: 0;
+}
+
 /*
  * Tray Plugin
  */

--- a/themes/kvantum/lxqt-panel.qss
+++ b/themes/kvantum/lxqt-panel.qss
@@ -179,6 +179,10 @@ LXQtPanel[position="1"] #DesktopSwitch QToolButton {
     border-radius: 3px;
 }
 
+#TaskBar LXQtGroupPopup QToolButton {
+    margin: 0;
+}
+
 #TaskBar LXQtGroupPopup > QToolButton:hover {
     background: rgba(255, 255, 255, 10%);
 }

--- a/themes/light/lxqt-panel.qss
+++ b/themes/light/lxqt-panel.qss
@@ -185,6 +185,11 @@ LXQtTaskButton {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #EFEFEF, stop:0.25 #e9e9e9, stop:0.5 #dfdfdf, stop:0.75 #d7d7d7, stop:1 #c0c0c0);
     border: 1px solid #80a8d3;
 }
+
+#TaskBar LXQtGroupPopup QToolButton {
+    margin: 0;
+}
+
 /*
  * Clock
  */

--- a/themes/silver/lxqt-panel.qss
+++ b/themes/silver/lxqt-panel.qss
@@ -470,6 +470,10 @@ LXQtFancyMenuWindow {
     border: 1px solid silver;
 }
 
+#TaskBar LXQtGroupPopup QToolButton {
+    margin: 0;
+}
+
 /*
  * Tray Plugin
  */


### PR DESCRIPTION
For most themes. Tested only with the Fusion Qt style. On Clearlooks:

Before:
![before](https://github.com/user-attachments/assets/756d4fce-ef92-4dd6-a625-4e4a43c9b728)

After:
![after](https://github.com/user-attachments/assets/c685f38b-40a7-44b5-a119-e7db30dfcf0e)
