### PR TITLE
Misc. 'Dark' theme improvements

### DIFF
--- a/themes/dark/lxqt-panel.qss
+++ b/themes/dark/lxqt-panel.qss
@@ -191,7 +191,6 @@ VolumePopup > QSlider::sub-page:vertical {
 
 #QuickLaunch QToolButton {
     border: 0px;
-    margin: 1px;
     padding: 2px;
 }
 
@@ -520,7 +519,7 @@ LXQtFancyMenuWindow {
 #FancyMenu QToolButton {
     margin: 3px;
     border-radius: 4px;
-    border: 1px solid transparent;
+    border: 1px solid #3c3c3c;
     padding: 4px;
     background: transparent;
 }
@@ -592,8 +591,8 @@ LXQtFancyMenuWindow {
 /*
  * Mount plugin
  */
-#LXQtMountPlugin {
-    margin: 2px;
+#LXQtMountPlugin QToolButton {
+    padding: 2px;
 }
 
 #LXQtMountPopup {

--- a/themes/dark/lxqt-panel.qss
+++ b/themes/dark/lxqt-panel.qss
@@ -727,12 +727,3 @@ LXQtFancyMenuWindow {
     margin-right: 2px;
     margin-left: 2px;
 }
-
-/*
- * CustomCommand Plugin
- */
-
-#Custom::hover {
-    background: black;
-    color: #f9f9f9;
-}


### PR DESCRIPTION
Changes:
- Because all widgets had full height except for mainmenu, fancymenu, and taskbar:
    - Give quicklaunch buttons full height
    - Give mount full height
- Give borders to fancymenu buttons

Questions:
- mainmenu has opacity whereas fancymenu doesn't, not sure if they both should, or ...
- Supplied icons "arrow-{left,right}.svg" and "calendar-popup/..." are not displaying for me. I'm not sure of the fix.