### PR TITLE
Theme disabled Backlight slider buttons

### DIFF
--- a/themes/Arch-Colors/lxqt-panel.qss
+++ b/themes/Arch-Colors/lxqt-panel.qss
@@ -651,6 +651,10 @@ QCalendarWidget QSpinBox {
     background: #1cb3ff;
 }
 
+#Backlight > SliderDialog > QToolButton:disabled {
+    color: #5b6d73;
+}
+
 #Backlight > SliderDialog {
     background: #041b27;
 }

--- a/themes/Clearlooks/lxqt-panel.qss
+++ b/themes/Clearlooks/lxqt-panel.qss
@@ -583,6 +583,10 @@ VolumePopup > QPushButton:pressed,
     border: 1px solid #888582;
 }
 
+#Backlight > SliderDialog > QToolButton:disabled {
+    color: #a0a0a0;
+}
+
 /* Calendar */
 QCalendarWidget QAbstractItemView {
     color: #000000;

--- a/themes/KDE-Plasma/lxqt-panel.qss
+++ b/themes/KDE-Plasma/lxqt-panel.qss
@@ -287,6 +287,10 @@ LXQtFancyMenuWindow {
     border-top: 3px solid rgba(30, 145, 255, 50%);
 }
 
+#Backlight > SliderDialog > QToolButton:disabled {
+    color: rgb(160, 160, 160);
+}
+
 /*
  * Sensors
  */

--- a/themes/Leech/lxqt-panel.qss
+++ b/themes/Leech/lxqt-panel.qss
@@ -641,6 +641,10 @@ VolumePopup > QPushButton:pressed,
     border: 1px solid #6a6b73;
 }
 
+#Backlight > SliderDialog > QToolButton:disabled {
+    color: #52501b;
+}
+
 /* Calendar */
 QCalendarWidget QAbstractItemView {
     color: #ffffff;

--- a/themes/Valendas/lxqt-panel.qss
+++ b/themes/Valendas/lxqt-panel.qss
@@ -545,6 +545,10 @@ VolumePopup > QSlider::sub-page:vertical {
     border-radius: 3px;
 }
 
+#Backlight > SliderDialog > QToolButton:disabled {
+    color: #a9abab;
+}
+
 #Backlight > SliderDialog {
     background-color: #2e2f2f;
     margin: 2px;

--- a/themes/ambiance/lxqt-panel.qss
+++ b/themes/ambiance/lxqt-panel.qss
@@ -94,7 +94,6 @@ Plugin > QWidget > QWidget {
     color: #f2f1f0;
 }
 
-
 Plugin > QToolButton,
 Plugin > QWidget > QToolButton,
 Plugin > QWidget > QToolButton > QWidget > QToolButton,
@@ -756,6 +755,10 @@ VolumePopup  > QSlider::sub-page:vertical {
 
 #Backlight > SliderDialog > QToolButton:hover {
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #f88657, stop:1 #eb7140);
+}
+
+#Backlight > SliderDialog > QToolButton:disabled {
+    color: #b1b1b1;
 }
 
 #Backlight > SliderDialog {

--- a/themes/dark/lxqt-panel.qss
+++ b/themes/dark/lxqt-panel.qss
@@ -124,6 +124,10 @@ VolumePopup > QSlider::sub-page:vertical {
     background: rgba(255, 255, 255, 20%);
 }
 
+#Backlight QToolButton:disabled {
+    color: #6D6D6D;
+}
+
 #Backlight > SliderDialog {
     background: hsv(0, 0, 41);
 }

--- a/themes/frost/lxqt-panel.qss
+++ b/themes/frost/lxqt-panel.qss
@@ -556,6 +556,10 @@ VolumePopup > QSlider::sub-page:vertical {
     color: palette(highlighted-text);
 }
 
+#Backlight > SliderDialog > QToolButton:disabled {
+    color: #6D6D6D;
+}
+
 #Backlight > SliderDialog {
     background: palette(text);
     margin: 2px;

--- a/themes/graphite/lxqt-panel.qss
+++ b/themes/graphite/lxqt-panel.qss
@@ -119,6 +119,10 @@ VolumePopup > QSlider::sub-page:vertical {
     background: rgba(255, 255, 255, 20%);
 }
 
+#Backlight QToolButton:disabled {
+    color: #6d6d6d;
+}
+
 #Backlight > SliderDialog {
     background: #303030;
 }

--- a/themes/kvantum/lxqt-panel.qss
+++ b/themes/kvantum/lxqt-panel.qss
@@ -657,6 +657,10 @@ VolumePopup > QSlider::handle:vertical {
     border: none;
 }
 
+#Backlight > SliderDialog > QToolButton:disabled {
+    color: rgba(255, 255, 255, 50%);
+}
+
 #Backlight > SliderDialog {
     margin: 0px;
     padding: 0px;

--- a/themes/silver/lxqt-panel.qss
+++ b/themes/silver/lxqt-panel.qss
@@ -634,6 +634,10 @@ VolumePopup > QSlider::sub-page:vertical {
     border-radius: 3px;
 }
 
+#Backlight > SliderDialog > QToolButton:disabled {
+    color: #6D6D6D;
+}
+
 #Backlight > SliderDialog {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2e2f2f, stop:1 #59595a);
     margin: 2px;


### PR DESCRIPTION
The Backlight popup is set to disabled when unavailable, but the buttons appeared active due to theming.
`color:` was taken from `QMenu::item:disabled`.