### PR TITLE
Make readable timezones popup on Frost theme.

### DIFF
--- a/themes/frost/lxqt-panel.qss
+++ b/themes/frost/lxqt-panel.qss
@@ -180,6 +180,12 @@ QCalendarWidget QSpinBox {
     selection-color: palette(highlighted-text);
 }
 
+
+LXQtWorldClockPopup {
+    color: #FFF;
+    background: #000;
+}
+
 /*
  * Main menu plugin
  */


### PR DESCRIPTION
Fixes one issue of https://github.com/lxqt/lxqt-themes/issues/157

For some reason this is the only combination which works, the code has probably some issues wit palette().

