### PR TITLE
update fsf address

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,7 +2,7 @@
                        Version 2.1, February 1999
 
  Copyright (C) 1991, 1999 Free Software Foundation, Inc.
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 


### PR DESCRIPTION
See https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html for the most current published address

On rpm based systems, when building, the old fsf address throws an Error in rpmlint.

This PR doesn't change any functionality, it's completely administrative.