### PR TITLE
Remove wallpaper symlink

### DIFF
--- a/themes/silver/beam.png
+++ b/themes/silver/beam.png
@@ -1,1 +1,0 @@
-../../wallpapers/beam.png


### PR DESCRIPTION
No need for it when it `wallpaper.cfg` pointed to `../../wallpapers/`. No other theme did so.