### PR TITLE
Lower excessive panel menu padding

### DIFF
--- a/themes/Arch-Colors/lxqt-panel.qss
+++ b/themes/Arch-Colors/lxqt-panel.qss
@@ -66,7 +66,6 @@ LXQtPanelPlugin > QToolButton:on {
 QMenu {
     background: #003d5b;
     border-radius: 3px;
-    min-width: 120px;
 }
 
 QMenu QToolButton {
@@ -81,7 +80,6 @@ QMenu::item {
     color: #d7e3e6;
     background: #041b27;
     padding: 5px 13px;
-    min-width: 120px;
 }
 
 QMenu::icon {

--- a/themes/Arch-Colors/lxqt-panel.qss
+++ b/themes/Arch-Colors/lxqt-panel.qss
@@ -66,6 +66,7 @@ LXQtPanelPlugin > QToolButton:on {
 QMenu {
     background: #003d5b;
     border-radius: 3px;
+    min-width: 120px;
 }
 
 QMenu QToolButton {
@@ -79,7 +80,8 @@ QMenu QToolButton {
 QMenu::item {
     color: #d7e3e6;
     background: #041b27;
-    padding: 5px 35px 5px 30px;
+    padding: 5px 13px;
+    min-width: 120px;
 }
 
 QMenu::icon {

--- a/themes/ambiance/lxqt-panel.qss
+++ b/themes/ambiance/lxqt-panel.qss
@@ -19,7 +19,6 @@ QToolTip {
 QMenu {
     background-color: #3c3b37;
     border: 1px solid #515048;
-    min-width: 120px;
 }
 
 QMenu::icon {
@@ -49,7 +48,6 @@ QMenu::right-arrow {
 QMenu::item {
     color: #f2f1f0;
     padding: 7px;
-    min-width: 120px;
 }
 
 QMenu::item:selected {

--- a/themes/ambiance/lxqt-panel.qss
+++ b/themes/ambiance/lxqt-panel.qss
@@ -19,6 +19,7 @@ QToolTip {
 QMenu {
     background-color: #3c3b37;
     border: 1px solid #515048;
+    min-width: 120px;
 }
 
 QMenu::icon {
@@ -47,7 +48,8 @@ QMenu::right-arrow {
 
 QMenu::item {
     color: #f2f1f0;
-    padding: 7px 40px 7px 24px;
+    padding: 7px;
+    min-width: 120px;
 }
 
 QMenu::item:selected {

--- a/themes/dark/lxqt-panel.qss
+++ b/themes/dark/lxqt-panel.qss
@@ -338,6 +338,7 @@ TrayIcon {
 QMenu {
     margin: 0px;
     padding: 2px;
+    min-width: 120px;
     border: 1px solid rgba(50, 50, 50, 80%);
     border-bottom-color: rgba(0, 0, 0, 80%);
     border-right-color: rgba(0, 0, 0, 80%);
@@ -368,7 +369,8 @@ QMenu::item {
     border-top-width: 1px;
     border-bottom-width: 1px;
     border-right-width: 5px;
-    padding: 6px 40px 6px 24px;
+    min-width: 120px;
+    padding: 6px;
     background: transparent;
     color: white;
 }

--- a/themes/dark/lxqt-panel.qss
+++ b/themes/dark/lxqt-panel.qss
@@ -338,7 +338,6 @@ TrayIcon {
 QMenu {
     margin: 0px;
     padding: 2px;
-    min-width: 120px;
     border: 1px solid rgba(50, 50, 50, 80%);
     border-bottom-color: rgba(0, 0, 0, 80%);
     border-right-color: rgba(0, 0, 0, 80%);
@@ -369,7 +368,6 @@ QMenu::item {
     border-top-width: 1px;
     border-bottom-width: 1px;
     border-right-width: 5px;
-    min-width: 120px;
     padding: 6px;
     background: transparent;
     color: white;

--- a/themes/frost/lxqt-panel.qss
+++ b/themes/frost/lxqt-panel.qss
@@ -73,20 +73,18 @@ LXQtPanelPlugin > QToolButton:pressed {
 QMenu {
     background-color: palette(text);
     padding: 0;
-    min-width: 120px;
 }
 
 QMenu::icon {
     background-color: transparent;
     border: 1px solid transparent;
-    padding-left: 6px;
+    padding: 0 4px;
 }
 
 QMenu::item {
     color: palette(window);
     border: 1px solid transparent;
-    padding: 5px 9px 5px 3px;
-    min-width: 120px;
+    padding: 5px;
 }
 
 QMenu::item:selected {

--- a/themes/frost/lxqt-panel.qss
+++ b/themes/frost/lxqt-panel.qss
@@ -73,18 +73,20 @@ LXQtPanelPlugin > QToolButton:pressed {
 QMenu {
     background-color: palette(text);
     padding: 0;
+    min-width: 120px;
 }
 
 QMenu::icon {
     background-color: transparent;
     border: 1px solid transparent;
-    padding-left: 2px;
+    padding-left: 6px;
 }
 
 QMenu::item {
     color: palette(window);
     border: 1px solid transparent;
-    padding: 5px 30px 5px 30px;
+    padding: 5px 9px 5px 3px;
+    min-width: 120px;
 }
 
 QMenu::item:selected {

--- a/themes/kvantum/lxqt-panel.qss
+++ b/themes/kvantum/lxqt-panel.qss
@@ -275,7 +275,7 @@ QMenu::separator {
 
 QMenu::item {
     border: 7px solid transparent;
-    padding: 0px 20px 0px 20px;
+    padding: 0px 7px;
     background: transparent;
     color: white;
 }

--- a/themes/light/lxqt-panel.qss
+++ b/themes/light/lxqt-panel.qss
@@ -92,12 +92,14 @@ QMenu {
     background: palette(window);
     border: 1px solid #AAA;
     border-radius: 2px;
+    min-width: 120px;
     color: palette(text);
 }
 
 QMenu::item {
     color: palette(text);
-    padding: 5px 27px;
+    padding: 5px 7px;
+    min-width: 120px;
 }
 
 QMenu::item:selected {

--- a/themes/light/lxqt-panel.qss
+++ b/themes/light/lxqt-panel.qss
@@ -92,14 +92,12 @@ QMenu {
     background: palette(window);
     border: 1px solid #AAA;
     border-radius: 2px;
-    min-width: 120px;
     color: palette(text);
 }
 
 QMenu::item {
     color: palette(text);
     padding: 5px 7px;
-    min-width: 120px;
 }
 
 QMenu::item:selected {


### PR DESCRIPTION
I think this is pretty straightforward, and not controversial. 

Before:

<img width="668" height="157" alt="before2" src="https://github.com/user-attachments/assets/b638b827-2828-43f5-961c-e03489677b33" />
<img width="276" height="263" alt="before3" src="https://github.com/user-attachments/assets/e6b4cd7b-791a-46b9-ae78-e2940ae4208f" />

----

After:

<img width="217" height="136" alt="after1" src="https://github.com/user-attachments/assets/94556243-d182-4796-86a9-3c3d4d228e6e" />

<img width="207" height="137" alt="after2" src="https://github.com/user-attachments/assets/31b7eb0e-f967-4c83-9dfd-c66a43d3bd16" />
